### PR TITLE
added levenshtein evaluation to api results, sorting results by status

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,8 @@
                  [org.clojure/data.csv "0.1.4"]
                  [clj-time "0.13.0"]
                  [clj-http "3.6.0"]
-                 [org.clojure/data.json "0.2.6"]]
+                 [org.clojure/data.json "0.2.6"]
+                 [clj-fuzzy "0.4.0"]]
   :plugins [[com.pupeno/jar-copier "0.4.0"]]
   :profiles {:dev {:resource-paths ["dev-resources"]}}
   :java-agents [[com.newrelic.agent.java/newrelic-agent "3.25.0"]]

--- a/src/vip/batch_address_test_tool/match.clj
+++ b/src/vip/batch_address_test_tool/match.clj
@@ -1,0 +1,19 @@
+(ns vip.batch-address-test-tool.match
+  (:require [clj-fuzzy.metrics :as metrics]))
+
+(defn calculate-score
+  "Calcuates the Levenshtein distance between expected polling location
+   and api results or -1 if api-result is nil."
+  [{:keys [expected-polling-location api-result]}]
+  (if api-result
+    (metrics/levenshtein expected-polling-location api-result)
+    -1))
+
+(defn calculate-match
+  "Calcuates a match based on the score."
+  [{:keys [score]}]
+    (cond
+      (= -1 score) "No Result"
+      (> 10 score) "Match"
+      (< 20 score) "Mismatch"
+      :else "Possible Mismatch"))

--- a/src/vip/batch_address_test_tool/processor.clj
+++ b/src/vip/batch_address_test_tool/processor.clj
@@ -74,8 +74,8 @@
 (defn calculate-scores*
   [ctx]
   (let [addresses (:addresses ctx)
-        scores (doall (map match/calculate-score addresses))
-        merged (mapv #(assoc %1 :score %2) addresses scores)]
+        scores (map match/calculate-score addresses)
+        merged (map #(assoc %1 :score %2) addresses scores)]
     (assoc ctx :addresses merged)))
 
 (def calculate-scores (->pass-through calculate-scores*))
@@ -83,8 +83,8 @@
 (defn calculate-matches*
   [ctx]
   (let [addresses (:addresses ctx)
-        matches (doall (map match/calculate-match addresses))
-        merged (mapv #(assoc %1 :match %2) addresses matches)]
+        matches (map match/calculate-match addresses)
+        merged (map #(assoc %1 :match %2) addresses matches)]
     (assoc ctx :addresses merged)))
 
 (def calculate-matches (->pass-through calculate-matches*))

--- a/test/vip/batch_address_test_tool/match_test.clj
+++ b/test/vip/batch_address_test_tool/match_test.clj
@@ -14,13 +14,11 @@
 
 (deftest calculate-match-test
   (testing "Match"
-    (dorun
-      (for [n (take 10 (iterate inc 0))]
-        (is (= "Match" (calculate-match {:score n}))))))
+    (doseq [n (range 10)]
+        (is (= "Match" (calculate-match {:score n})))))
   (testing "Possible Mismatch"
-    (dorun
-      (for [n (take 11 (iterate inc 10))]
-        (is (= "Possible Mismatch" (calculate-match {:score n}))))))
+    (doseq [n (range 10 21)]
+        (is (= "Possible Mismatch" (calculate-match {:score n})))))
   (testing "Mismatch"
     (is (= "Mismatch" (calculate-match {:score 21}))))
   (testing "No Result"

--- a/test/vip/batch_address_test_tool/match_test.clj
+++ b/test/vip/batch_address_test_tool/match_test.clj
@@ -1,0 +1,27 @@
+(ns vip.batch-address-test-tool.match-test
+  (:require [vip.batch-address-test-tool.match :refer :all]
+            [clojure.test :refer :all]))
+
+(deftest calculate-score-test
+  (testing "Exact match"
+    (is (= 0 (calculate-score {:expected-polling-location "foo"
+                               :api-result "foo"}))))
+  (testing "Off by 1"
+    (is (= 1 (calculate-score {:expected-polling-location "foo1"
+                               :api-result "foo"}))))
+  (testing "No API result"
+    (is (= -1 (calculate-score {:expected-polling-location "foo"})))))
+
+(deftest calculate-match-test
+  (testing "Match"
+    (dorun
+      (for [n (take 10 (iterate inc 0))]
+        (is (= "Match" (calculate-match {:score n}))))))
+  (testing "Possible Mismatch"
+    (dorun
+      (for [n (take 11 (iterate inc 10))]
+        (is (= "Possible Mismatch" (calculate-match {:score n}))))))
+  (testing "Mismatch"
+    (is (= "Mismatch" (calculate-match {:score 21}))))
+  (testing "No Result"
+    (is (= "No Result" (calculate-match {:score -1})))))

--- a/test/vip/batch_address_test_tool/processor_test.clj
+++ b/test/vip/batch_address_test_tool/processor_test.clj
@@ -51,4 +51,4 @@
     (is (= ["foo" "bar" "baz" "blee"] (->result-row {:address "foo"
                                                      :expected-polling-location "bar"
                                                      :api-result "baz"
-                                                     :status "blee"})))))
+                                                     :match "blee"})))))


### PR DESCRIPTION
For [this card](https://www.pivotaltracker.com/story/show/145070071) on calculating the match based on Levenshtein distance and [this card](https://www.pivotaltracker.com/story/show/145070177) on sorting the output based on the severity of mismatch.

We added a new namespace [`vip.batch-address-test-tool.match`](https://github.com/votinginfoproject/batch-address-test-tool/compare/query-civic-info-api...evaluate-match?expand=1#diff-147d23fd8fa1646814364f5fb26cd88d) with a function to take the results and calculate the Levenschtein score (`calcualate-score`) and then another function that takes those scores and sorts them into "Match", "Possible Mismatch", "Mismatch", and "No Result" (`calculate-match`).  We then sort the output based on the score in descending order with "No Results" being equivalent to -1 so those go at the bottom as requested.  The match evaluation and sorting is based on the card and also on the code that was implemented in the spreadsheet tool [here](https://script.google.com/a/macros/turbovote.org/d/MMXrzPhAoFEmaNqOeXuY4VSDlqUzmhjH_/edit?uiv=2&mid=ACjPJvFis8vA0ws1ISTrhPlllWyGaW_XwjAgloBOqSdcp6PdzLmey-iQGPts-ZxPGuuVZ0naDcH2gdN7BJ1nRJg09jlr4bKOqAg92s_WrH3WZN6JS4p-CEUHNU1i0YCGuCBdH6RZteet0A).