### PR TITLE
added groupName and transactionId to response message

### DIFF
--- a/src/vip/batch_address_test_tool/processor.clj
+++ b/src/vip/batch_address_test_tool/processor.clj
@@ -136,7 +136,9 @@
     (let [response-message {"fileName" (get-in ctx [:results :file-name])
                             "bucketName" (get-in ctx [:results :bucket-name])
                             "status" "ok"
-                            "url" (get-in ctx [:results :url])}]
+                            "url" (get-in ctx [:results :url])
+                            "groupName" (get-in ctx [:input "groupName"])
+                            "transactionID" (get-in ctx [:input "transactionId"])}]
       (q/publish-to-queue response-message "batch-address.file.complete"))))
 
 (defn process-message

--- a/src/vip/batch_address_test_tool/processor.clj
+++ b/src/vip/batch_address_test_tool/processor.clj
@@ -138,7 +138,7 @@
                             "status" "ok"
                             "url" (get-in ctx [:results :url])
                             "groupName" (get-in ctx [:input "groupName"])
-                            "transactionID" (get-in ctx [:input "transactionId"])}]
+                            "transactionId" (get-in ctx [:input "transactionId"])}]
       (q/publish-to-queue response-message "batch-address.file.complete"))))
 
 (defn process-message


### PR DESCRIPTION
When we first tested the response message from this repository wasn't working properly so when Metis picked up the message it didn't have the information it needed to send the email alert that the file was completed.  This adds the `groupName` and `transactionId` from the original message to the response message submitted by the `batch-address-test-tool`.