### PR TITLE
updated group to get groupName from input message and not filename

### DIFF
--- a/src/vip/batch_address_test_tool/processor.clj
+++ b/src/vip/batch_address_test_tool/processor.clj
@@ -115,7 +115,7 @@
 (defn prepare-response*
   "Saves output file to s3 and generates data for response message"
   [ctx]
-  (let [group (->group (get-in ctx [:input "fileName"]))
+  (let [group (->group (get-in ctx [:input "groupName"]))
         bucket-name (get-in ctx [:input "bucketName"])
         output-file-name (str/join "/" [group "output" "results.csv"])
         output-file (->results-file ctx)]


### PR DESCRIPTION
There was a mismatch between how Metis was naming files and how we're doing it here; I'm sticking with how the naming works here (I think it's a bit cleaner) so there's a PR to fix how Metis does the naming and then we were somehow not pulling the groupName out correctly.  Metis PR [here](https://github.com/votinginfoproject/Metis/pull/372)