### PR TITLE
added groupName and transactionId to the return message when there's …

### DIFF
--- a/src/vip/batch_address_test_tool/processor.clj
+++ b/src/vip/batch_address_test_tool/processor.clj
@@ -131,7 +131,9 @@
   [ctx]
   (if (contains? ctx :error)
     (q/publish-to-queue {"status" "error"
-                         "error" {"message" (.getMessage (:error ctx))}}
+                         "error" {"message" (.getMessage (:error ctx))}
+                         "groupName" (get-in ctx [:input "groupName"])
+                         "transactionId" (get-in ctx [:input "transactionId"])}
                         "batch-address.file.complete")
     (let [response-message {"fileName" (get-in ctx [:results :file-name])
                             "bucketName" (get-in ctx [:results :bucket-name])


### PR DESCRIPTION
We added the `groupName` and `transactionId` to the happy-path return messages but failed to add them to the error messages.  Let's fix that!