### PR TITLE
skip rows that result from blank lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Clojure library that tests addresses for the Voting Information Project.
 
+TODO: fill in more information about project
+
 ## Usage
 
 Run with `lein run`

--- a/script/build
+++ b/script/build
@@ -18,7 +18,6 @@ docker build -t $DOCKER_IMAGE .
 
 if [ $CI = "true" ]; then
     echo '--- pushing docker image to registry'
-    docker login -e="." -u="${QUAY_USERNAME}" -p="${QUAY_PASSWORD}" quay.io
     docker push $DOCKER_IMAGE
 else
     echo "If you'd like to push this to the Docker repo, run: docker push ${DOCKER_IMAGE}"

--- a/script/build
+++ b/script/build
@@ -16,7 +16,7 @@ DOCKER_IMAGE=$DOCKER_REPO:$IMAGE_TAG
 echo '--- building docker image'
 docker build -t $DOCKER_IMAGE .
 
-if [[ $CI = "true" && $BUILDKITE_BRANCH = "master" ]]; then
+if [[ $CI = "true"]]; then
     echo '--- pushing docker image to registry'
     docker login -e="." -u="${QUAY_USERNAME}" -p="${QUAY_PASSWORD}" quay.io
     docker push $DOCKER_IMAGE
@@ -29,7 +29,7 @@ cp ${SERVICE}@.service.template ${SERVICE}@.service
 
 perl -p -i -e "s|^Environment=DOCKER_IMAGE=.*$|Environment=DOCKER_IMAGE=${DOCKER_IMAGE}|" ${SERVICE}@.service
 
-if [[ $CI = "true" && $BUILDKITE_BRANCH = "master" ]]; then
+if hash buildkite-agent 2>/dev/null ; then
   echo '--- saving service file'
   buildkite-agent artifact upload ${SERVICE}@.service
 fi

--- a/script/build
+++ b/script/build
@@ -18,6 +18,7 @@ docker build -t $DOCKER_IMAGE .
 
 if [ $CI = "true" ]; then
     echo '--- pushing docker image to registry'
+    docker login -e="." -u="${QUAY_USERNAME}" -p="${QUAY_PASSWORD}" quay.io
     docker push $DOCKER_IMAGE
 else
     echo "If you'd like to push this to the Docker repo, run: docker push ${DOCKER_IMAGE}"

--- a/script/build
+++ b/script/build
@@ -16,7 +16,7 @@ DOCKER_IMAGE=$DOCKER_REPO:$IMAGE_TAG
 echo '--- building docker image'
 docker build -t $DOCKER_IMAGE .
 
-if [[ $CI = "true"]]; then
+if [ $CI = "true" ]; then
     echo '--- pushing docker image to registry'
     docker login -e="." -u="${QUAY_USERNAME}" -p="${QUAY_PASSWORD}" quay.io
     docker push $DOCKER_IMAGE

--- a/script/deploy
+++ b/script/deploy
@@ -14,19 +14,6 @@ if [[ ! -e ${SERVICE}@.service ]]; then
   exit 1
 fi
 
-if hash buildkite-agent 2>/dev/null ; then
-  echo "--- deploying from coreos node"
-else
-  if [[ ! -e $PEM_FILE ]]; then
-    echo "Please provide a .pem file for the fleet"
-    exit 1
-  fi
-
-  echo "--- setting up SSH"
-  eval "$(ssh-agent -s)"
-  ssh-add $PEM_FILE
-fi
-
 echo "--- sending fleet service file"
 fleetctl --strict-host-key-checking=false destroy ${SERVICE}@.service || true
 fleetctl --strict-host-key-checking=false submit ${SERVICE}@.service

--- a/script/deploy
+++ b/script/deploy
@@ -14,6 +14,9 @@ if [[ ! -e ${SERVICE}@.service ]]; then
   exit 1
 fi
 
+eval "$(ssh-agent -s)"
+ssh-add
+
 echo "--- sending fleet service file"
 fleetctl --strict-host-key-checking=false destroy ${SERVICE}@.service || true
 fleetctl --strict-host-key-checking=false submit ${SERVICE}@.service

--- a/script/deploy
+++ b/script/deploy
@@ -14,14 +14,20 @@ if [[ ! -e ${SERVICE}@.service ]]; then
   exit 1
 fi
 
-if [[ ! -e $PEM_FILE ]]; then
-  echo "Please provide a .pem file for the fleet"
-  exit 1
+if hash buildkite-agent 2>/dev/null ; then
+  echo "--- deploying from coreos node"
+else
+  if [[ ! -e $PEM_FILE ]]; then
+    echo "Please provide a .pem file for the fleet"
+    exit 1
+  fi
+
+  echo "--- setting up SSH"
+  eval "$(ssh-agent -s)"
+  ssh-add $PEM_FILE
 fi
 
-eval "$(ssh-agent -s)"
-ssh-add $PEM_FILE
-
+echo "--- sending fleet service file"
 fleetctl --strict-host-key-checking=false destroy ${SERVICE}@.service || true
 fleetctl --strict-host-key-checking=false submit ${SERVICE}@.service
 

--- a/script/deploy
+++ b/script/deploy
@@ -14,9 +14,6 @@ if [[ ! -e ${SERVICE}@.service ]]; then
   exit 1
 fi
 
-eval "$(ssh-agent -s)"
-ssh-add
-
 echo "--- sending fleet service file"
 fleetctl --strict-host-key-checking=false destroy ${SERVICE}@.service || true
 fleetctl --strict-host-key-checking=false submit ${SERVICE}@.service

--- a/src/vip/batch_address_test_tool/processor.clj
+++ b/src/vip/batch_address_test_tool/processor.clj
@@ -48,12 +48,17 @@
     {:address (first row)
      :expected-polling-location (second row)}))
 
+(defn not-blank-row? [row]
+  (not (and (= 1 (count row))
+            (str/blank? (first row)))))
+
 (defn validate-and-parse-file*
   "Calls validate-header-row on first row in file and maps remaining rows with
    validate-and-parse-row"
   [ctx]
   (try
-    (let [rows (take 301 (csv/read-csv (:address-file ctx)))]
+    (let [rows (take 301 (filter not-blank-row?
+                                 (csv/read-csv (:address-file ctx))))]
       (validate-header-row (first rows))
       (assoc ctx :addresses
              (doall (map validate-and-parse-row (rest rows)))))

--- a/src/vip/batch_address_test_tool/queue.clj
+++ b/src/vip/batch_address_test_tool/queue.clj
@@ -24,7 +24,7 @@
        (handler-fn message))
       (catch Exception ex
         (log/error "Error consuming message" (String. payload))
-        (log/error (.getMessage ex))))))
+        (log/error ex)))))
 
 (defn setup-consumer
   "Sets up the handler function to process messages on the

--- a/test/vip/batch_address_test_tool/processor_test.clj
+++ b/test/vip/batch_address_test_tool/processor_test.clj
@@ -4,41 +4,37 @@
 
 (deftest validate-header-row-test
   (testing "Throws error with less than two elements in header row"
-    (is (thrown-with-msg? Exception #"Incorrect number of headers, expected 2"
-                          (validate-header-row nil)))
-    (is (thrown-with-msg? Exception #"Incorrect number of headers, expected 2"
-                          (validate-header-row [])))
-    (is (thrown-with-msg? Exception #"Incorrect number of headers, expected 2"
-                          (validate-header-row ["voter_address"]))))
+    (is (thrown-with-msg? Exception #"Incorrect number of headers, expected 2 on line number 1"
+                          (validate-header-row [0 []])))
+    (is (thrown-with-msg? Exception #"Incorrect number of headers, expected 2 on line number 1"
+                          (validate-header-row [0 ["voter_address"]]))))
   (testing "Throws error with more than two elements in header row"
-    (is (thrown-with-msg? Exception #"Incorrect number of headers, expected 2"
-                          (validate-header-row ["voter_address" "expected_polling_location" "Polling Location Result"]))))
+    (is (thrown-with-msg? Exception #"Incorrect number of headers, expected 2 on line number 2"
+                          (validate-header-row [1 ["voter_address" "expected_polling_location" "Polling Location Result"]]))))
   (testing "Test first header element"
     (is (thrown-with-msg? Exception #"Expected first header item to be \"voter_address\""
-                          (validate-header-row ["Voter Address" "expected_polling_location"]))))
+                          (validate-header-row [1 ["Voter Address" "expected_polling_location"]]))))
   (testing "Test second header element"
     (is (thrown-with-msg? Exception #"Expected second header item to be \"expected_polling_location\""
-                          (validate-header-row ["voter_address" "Polling Location Result"]))))
+                          (validate-header-row [0 ["voter_address" "Polling Location Result"]]))))
   (testing "Good header row"
     (try
-      (validate-header-row ["voter_address" "expected_polling_location"])
+      (validate-header-row [0 ["voter_address" "expected_polling_location"]])
       (catch Exception ex
         (is (= 0 1) "Unexpected exception validating a good header row")))))
 
 (deftest validate-and-parse-row-test
   (testing "Throws error with less than two elements in row"
-    (is (thrown-with-msg? Exception #"Incorrect number of row elements, expected 2"
-                          (validate-and-parse-row nil)))
-    (is (thrown-with-msg? Exception #"Incorrect number of row elements, expected 2"
-                          (validate-and-parse-row [])))
-    (is (thrown-with-msg? Exception #"Incorrect number of row elements, expected 2"
-                          (validate-and-parse-row ["123 Main Street, Springfield, IL 12345"]))))
+    (is (thrown-with-msg? Exception #"Incorrect number of row elements, expected 2 on line number 2"
+                          (validate-and-parse-row [1 []])))
+    (is (thrown-with-msg? Exception #"Incorrect number of row elements, expected 2 on line number 3"
+                          (validate-and-parse-row [2 ["123 Main Street, Springfield, IL 12345"]]))))
   (testing "Throws an error with more than 2 elements in a row"
-    (is (thrown-with-msg? Exception #"Incorrect number of row elements, expected 2"
-                          (validate-and-parse-row ["123 Main Street, Springfield, IL, 12345" "Homer Elementary School, 234 Main Street, Springfield, IL, 12345" "other unexpected data"]))))
+    (is (thrown-with-msg? Exception #"Incorrect number of row elements, expected 2 on line number 3"
+                          (validate-and-parse-row [2 ["123 Main Street, Springfield, IL, 12345" "Homer Elementary School, 234 Main Street, Springfield, IL, 12345" "other unexpected data"]]))))
   (testing "Good address row"
     (try
-      (let [results (validate-and-parse-row ["123 Main Street, Springfield, IL, 12345" "Homer Elementary School, 234 Main Street, Springfield, IL, 12345"])]
+      (let [results (validate-and-parse-row [2 ["123 Main Street, Springfield, IL, 12345" "Homer Elementary School, 234 Main Street, Springfield, IL, 12345"]])]
         (is (= (results {:address "123 Main Street, Springfield, IL, 12345"
                          :expected-polling-location "Homer Elementary School, 234 Main Street, Springfield, IL, 12345"}))))
       (catch Exception ex

--- a/test/vip/batch_address_test_tool/processor_test.clj
+++ b/test/vip/batch_address_test_tool/processor_test.clj
@@ -44,6 +44,15 @@
       (catch Exception ex
         (is (= 0 1) "Unexpected exception validating a good address row")))))
 
+(deftest validate-and-parse-file*-test
+  (testing "skips empty rows, even at top of file"
+    (let [ctx {:address-file "\nvoter_address,expected_polling_location\n\n1,2\n\n"}
+          parsed-ctx (validate-and-parse-file* ctx)]
+      (is (= 1 (count (:addresses parsed-ctx))))
+      (is (= {:address "1"
+              :expected-polling-location "2"}
+             (-> parsed-ctx :addresses first))))))
+
 (deftest ->result-row-test
   (testing "Partial result"
     (is (= ["foo" "bar" "" ""] (->result-row {:address "foo" :expected-polling-location "bar"}))))


### PR DESCRIPTION
Pretty simple fix for [this Pivotal Card](https://www.pivotaltracker.com/story/show/150052592).

When a blank row is in a CSV, it gets parsed as a row with a single empty string, and so it's pretty easy
to filter that out. I put it before the `take` call so that blank rows won't count against the 300 address limit.