### PR TITLE
Add polling place count

### DIFF
--- a/src/vip/batch_address_test_tool/civic_info.clj
+++ b/src/vip/batch_address_test_tool/civic_info.clj
@@ -14,7 +14,7 @@
                    (:state address) " "
                    (:zip address)))))
 
-(defn address->polling-location
+(defn address->polling-location-info
   [address]
   (let [api-key (config [:civic-info-api-key])
         url "https://www.googleapis.com/civicinfo/v2/voterinfo"
@@ -26,4 +26,5 @@
         response (client/get url opts)]
       (log/debug "queried civic info API with address" (pr-str address)
                  "and received status code" (:status response))
-      (response->polling-location response)))
+      {:api-result  (response->polling-location response)
+       :polling-location-count (-> response :body :pollingLocations count)}))

--- a/src/vip/batch_address_test_tool/processor.clj
+++ b/src/vip/batch_address_test_tool/processor.clj
@@ -83,8 +83,9 @@
 (defn retrieve-polling-locations*
   [ctx]
   (let [addresses (:addresses ctx)
-        polling-locations (map #(civic-info/address->polling-location (:address %)) addresses)
-        merged (map #(assoc %1 :api-result %2) addresses polling-locations)]
+        polling-location-info (map #(civic-info/address->polling-location-info
+                                     (:address %)) addresses)
+        merged (map #(merge %1 %2) addresses polling-location-info)]
     (assoc ctx :addresses merged)))
 
 (def retrieve-polling-locations (->pass-through retrieve-polling-locations*))
@@ -115,12 +116,12 @@
 (defn ->result-row
   "Creates a vector of values from result suitable for csv writing"
   [result]
-  (map #(get result % "") [:address :expected-polling-location :api-result :match]))
+  (map #(get result % "") [:address :expected-polling-location :api-result :polling-location-count :match]))
 
 (defn ->results-file
   "Creates the csv data and writes it to a temp file"
   [ctx]
-  (let [header [["voter_address" "expected_polling_location" "api_result" "status"]]
+  (let [header [["voter_address" "expected_polling_location" "api_result" "polling_location_count" "status"]]
         addresses (:addresses ctx)
         sorted (reverse (sort-by :score addresses))
         result-rows (map ->result-row sorted)

--- a/src/vip/batch_address_test_tool/queue.clj
+++ b/src/vip/batch_address_test_tool/queue.clj
@@ -30,6 +30,7 @@
   "Sets up the handler function to process messages on the
    batch-address.file.submit channel"
   [ch handler-fn]
+  (lq/declare ch "batch-address.file.submit" {:durable true :auto-delete false})
   (lcons/subscribe ch "batch-address.file.submit"
                  (->handler handler-fn)
                  {:auto-ack true}))

--- a/test/vip/batch_address_test_tool/processor_test.clj
+++ b/test/vip/batch_address_test_tool/processor_test.clj
@@ -51,9 +51,10 @@
 
 (deftest ->result-row-test
   (testing "Partial result"
-    (is (= ["foo" "bar" "" ""] (->result-row {:address "foo" :expected-polling-location "bar"}))))
+    (is (= ["foo" "bar" "" "" ""] (->result-row {:address "foo" :expected-polling-location "bar"}))))
   (testing "Full result"
-    (is (= ["foo" "bar" "baz" "blee"] (->result-row {:address "foo"
-                                                     :expected-polling-location "bar"
-                                                     :api-result "baz"
-                                                     :match "blee"})))))
+    (is (= ["foo" "bar" "baz" 1 "blee"] (->result-row {:address "foo"
+                                                       :expected-polling-location "bar"
+                                                       :api-result "baz"
+                                                       :polling-location-count 1
+                                                       :match "blee"})))))


### PR DESCRIPTION
Adds polling_place_count to the results file.

I also added some debug logging we can turn on in dev to see the progress and debug issues. And I added a queue declare for the `batch-address.file.submit` queue so we can start up without needing to have it created first by Metis.

[Pivotal Card](https://www.pivotaltracker.com/story/show/150650489)