### PR TITLE
Handle odd windows line endings

### DIFF
--- a/dev-src/clj/batch_address_test_tool/dev.clj
+++ b/dev-src/clj/batch_address_test_tool/dev.clj
@@ -6,6 +6,7 @@
   (let [ctx {:address-file-contents (slurp file-path)}]
     (try
       (-> ctx
+          p/cleanup-source-file
           p/validate-and-parse-file
           clojure.pprint/pprint)
       (catch Exception ex

--- a/dev-src/clj/batch_address_test_tool/dev.clj
+++ b/dev-src/clj/batch_address_test_tool/dev.clj
@@ -1,0 +1,25 @@
+(ns batch-address-test-tool.dev
+  (:require [vip.batch-address-test-tool.processor :as p])
+  (:gen-class))
+
+(defn test-parse-file [file-path]
+  (let [ctx {:address-file-contents (slurp file-path)}]
+    (try
+      (-> ctx
+          p/validate-and-parse-file
+          clojure.pprint/pprint)
+      (catch Exception ex
+        (println "error!")
+        (clojure.pprint/pprint ex)))))
+
+(defn clean-line-endings [file-path]
+  (let [in-file (slurp file-path)]
+    (try
+      (spit (str "corrected-" file-path)
+            (clojure.string/replace in-file #"\r\n" "\n"))
+      (catch Exception ex
+        (println "error!")
+        (clojure.pprint/pprint ex)))))
+
+(defn -main [filename]
+  (test-parse-file filename))

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,8 @@
                  [org.clojure/data.json "0.2.6"]
                  [clj-fuzzy "0.4.0"]]
   :plugins [[com.pupeno/jar-copier "0.4.0"]]
-  :profiles {:dev {:resource-paths ["dev-resources"]}}
+  :profiles {:dev {:resource-paths ["dev-resources"]
+                   :source-paths ["dev-src/clj"]}}
   :java-agents [[com.newrelic.agent.java/newrelic-agent "3.25.0"]]
   :jar-copier {:java-agents true
                :destination "resources/jars"}

--- a/src/vip/batch_address_test_tool/civic_info.clj
+++ b/src/vip/batch_address_test_tool/civic_info.clj
@@ -19,7 +19,9 @@
   (let [api-key (config [:civic-info-api-key])
         url "https://www.googleapis.com/civicinfo/v2/voterinfo"
         params {"address" address
-                "key" api-key}
+                "key" api-key
+                "officialData" true
+                "productionDataOnly" false}
         opts {:query-params params
               :as :json
               :throw-exceptions false}

--- a/test/vip/batch_address_test_tool/processor_test.clj
+++ b/test/vip/batch_address_test_tool/processor_test.clj
@@ -40,9 +40,21 @@
       (catch Exception ex
         (is (= 0 1) "Unexpected exception validating a good address row")))))
 
+(deftest cleanup-source-file*-test
+  (testing "leaves a good file content alone"
+    (let [ctx {:address-file-contents "voter_address,expected_polling_location\n1,2\n"}
+          cleaned-ctx (cleanup-source-file* ctx)]
+      (is (= "voter_address,expected_polling_location\n1,2\n"
+             (:address-file-contents cleaned-ctx)))))
+  (testing "cleans up pesky windows line endings"
+    (let [ctx {:address-file-contents "voter_address,expected_polling_location\r\n1,2\r\n"}
+          cleaned-ctx (cleanup-source-file* ctx)]
+      (is (= "voter_address,expected_polling_location\n1,2\n"
+             (:address-file-contents cleaned-ctx))))))
+
 (deftest validate-and-parse-file*-test
   (testing "skips empty rows, even at top of file"
-    (let [ctx {:address-file "\nvoter_address,expected_polling_location\n\n1,2\n\n"}
+    (let [ctx {:address-file-contents "\nvoter_address,expected_polling_location\n\n1,2\n\n"}
           parsed-ctx (validate-and-parse-file* ctx)]
       (is (= 1 (count (:addresses parsed-ctx))))
       (is (= {:address "1"


### PR DESCRIPTION
[Pivotal Card]()

Does a few things:
* First, the `dev.clj` file wasn't in a proper namespace because the directory had `-` instead of `_`, so I fixed that, and made a main class so I could test parse a file.
* Second, added a processor step to clean up the source file contents, in this case replacing `\r\n` with just `\n`.
* Third, sets some more api parameters that need to be set explicitly to get staging results.